### PR TITLE
add github actions for android

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,23 @@
+name: Android CI
+
+on:
+  pull_request:
+    branches: [ main, develop ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Run Compile
+        run: ./gradlew assembleDebug


### PR DESCRIPTION
It resolves issue 
- https://github.com/GDSC-DSI/Schedura/issues/30

> if Github actions on a Node js project will help us.

In your issue, you mention Node js, but isn't Java the tool we use for Android development ?

> We can setup a basic Github Action for each PR

In this PR, I created a task that builds the app when PR is created for main, develop.


Sorry, it is difficult for me to use English. (I'm Japanese)

I apologize if my opinion or PR is wrong.
